### PR TITLE
Bugfix for undefined ReactiveVar

### DIFF
--- a/client/init.coffee
+++ b/client/init.coffee
@@ -1,5 +1,5 @@
 # Manually initialize the router into a nested div
-polymerReady = new ReactiveVar false
+polymerReady = new Blaze.ReactiveVar false
 
 $(window).on "polymer-ready", ->
   polymerReady.set true


### PR DESCRIPTION
Loved the video and am anxious to dig into the demo, but I immediately got  ref error that ReactiveVar was not defined. Looks like adding `Blaze.` to the front does the trick.
